### PR TITLE
do not use deprecated python client method

### DIFF
--- a/wazo_export_import/helpers/importer.py
+++ b/wazo_export_import/helpers/importer.py
@@ -172,8 +172,8 @@ class WazoAPI:
                     print("tenant slug already used")
                 raise
 
-        self._auth_client.set_tenant(self._tenant_uuid)
-        self._confd_client.set_tenant(self._tenant_uuid)
+        self._auth_client.tenant_uuid = self._tenant_uuid
+        self._confd_client.tenant_uuid = self._tenant_uuid
 
     def list_contexts(self):
         return self._confd_client.contexts.list()["items"]

--- a/wazo_export_import/helpers/tests/test_importer.py
+++ b/wazo_export_import/helpers/tests/test_importer.py
@@ -28,8 +28,8 @@ class TestWazoAPI(unittest.TestCase):
 
         api.set_tenant()
 
-        api._auth_client.set_tenant.assert_called_once_with(s.tenant)
-        api._confd_client.set_tenant.assert_called_once_with(s.tenant)
+        assert api._auth_client.tenant_uuid == s.tenant
+        assert api._confd_client.tenant_uuid == s.tenant
 
     def test_set_tenant_with_new_tenant(self):
         api = WazoAPI(s.username, s.password, tenant_slug=s.tenant_slug)
@@ -40,10 +40,10 @@ class TestWazoAPI(unittest.TestCase):
 
         api.set_tenant()
 
-        api._auth_client.set_tenant.assert_called_once_with(s.tenant_uuid)
-        api._confd_client.set_tenant.assert_called_once_with(s.tenant_uuid)
         api._auth_client.tenants.new.assert_called_once_with(
             name=s.tenant_slug,
             slug=s.tenant_slug,
         )
+        assert api._auth_client.tenant_uuid == s.tenant_uuid
+        assert api._confd_client.tenant_uuid == s.tenant_uuid
         assert api._tenant_uuid == s.tenant_uuid


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-lib-rest-client/pull/10